### PR TITLE
Fixed blazor toolkit chart rendering issue in SSR

### DIFF
--- a/src/Components/Charts/Chart/Renderer/ChartElementRenderer.cs
+++ b/src/Components/Charts/Chart/Renderer/ChartElementRenderer.cs
@@ -128,6 +128,11 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
                 return;
             }
 
+            if (IsStaticSSR())
+            {
+                SetDefaultRendererValues();
+            }
+
             this.CreateCascadingValue(builder, 0, 1, this, 2,
                BuildRenderers);
             RendererShouldRender = false;
@@ -203,6 +208,13 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
         internal void Prerender()
         {
             ContainerUpdate = true;
+
+            if (IsStaticSSR())
+            {
+                ContainerPrerender = true;
+                RendererShouldRender = true;
+                SetDefaultRendererValues();
+            }
             _ = InvokeAsync(StateHasChanged);
         }
         #endregion

--- a/src/Components/Charts/Chart/Renderer/SeriesRenderers/BaseRenderers/SeriesContainer.cs
+++ b/src/Components/Charts/Chart/Renderer/SeriesRenderers/BaseRenderers/SeriesContainer.cs
@@ -371,11 +371,15 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
         /// <summary>
         /// Creates nested renderer components for a given series element, such as marker renderer, data label renderer, error bar renderer, and gradient renderers, based on the presence of their respective RendererType properties. Each nested renderer is also assigned a unique key for Blazor's rendering system. This method ensures that all auxiliary renderers associated with a series are instantiated and linked to the series for proper rendering of markers, labels, error bars, and gradients as needed.
         /// </summary>
-        private static void CreateSeriesNestedElements(RenderTreeBuilder builder, ChartSeries element)
+        private static void CreateSeriesNestedElements(RenderTreeBuilder builder, ChartSeries element, SfChart Chart)
         {
             int seq = 0;
             ChartSeries series = element;
-            if (series.Marker?.RendererType is not null)
+            bool isStaticSsr = Chart != null && Chart.IsStaticServerRendering();
+
+            bool shouldOpenMarker = series.Marker?.RendererType is not null &&
+                        (series.Marker.Visible || series.Marker.DataLabel.Visible || isStaticSsr);
+            if (shouldOpenMarker)
             {
                 builder.OpenComponent(seq++, series.Marker.RendererType);
                 builder.AddAttribute(seq++, "Series", series);
@@ -706,7 +710,7 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
 
                 foreach (ChartSeries element in Elements.Cast<ChartSeries>())
                 {
-                    CreateSeriesNestedElements(builder, element);
+                    CreateSeriesNestedElements(builder, element, Owner ?? null!);
                 }
             }
             else
@@ -736,7 +740,7 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
                             continue;
                         }
 
-                        CreateSeriesNestedElements(builder, element);
+                        CreateSeriesNestedElements(builder, element, Owner ?? null!);
                     }
                 }
             }
@@ -972,6 +976,16 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
                 ProcessData();
                 Owner?._legendRenderer?.SetDefaultRendererValues();
                 Owner?._axisContainer?.SetDefaultRendererContainerValues();
+                if (Owner?.InitialRect is not null)
+                {
+                    HandleChartSizeChange(Owner.InitialRect);
+                    foreach (var seriesRenderer in Renderers.OfType<ChartSeriesRenderer>())
+                    {
+                        seriesRenderer.Series?.Marker?.Renderer?.HandleChartSizeChange(Owner.InitialRect);
+                    }
+                    Owner?._striplineBehindContainer?.SetDefaultRendererValues();
+                    Owner?._striplineOverContainer?.SetDefaultRendererValues();
+                }
             }
             catch
             {
@@ -1098,6 +1112,19 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
             foreach (ChartRenderer renderer in Renderers.Cast<ChartRenderer>())
             {
                 renderer.HandleChartSizeChange(rect);
+            }
+
+            if (IsStaticSSR())
+            {
+                // Markers again if they were null during series pass
+                foreach (var seriesRenderer in Renderers.OfType<ChartSeriesRenderer>())
+                {
+                    seriesRenderer.Series?.Marker?.Renderer?.HandleChartSizeChange(rect);
+                }
+
+                // Striplines after axis + series clip are final
+                Owner?._striplineBehindContainer?.UpdateStriplineCollection();
+                Owner?._striplineOverContainer?.UpdateStriplineCollection();
             }
         }
 

--- a/src/Components/Charts/Chart/Renderer/SeriesRenderers/BaseRenderers/SeriesContainer.cs
+++ b/src/Components/Charts/Chart/Renderer/SeriesRenderers/BaseRenderers/SeriesContainer.cs
@@ -371,14 +371,13 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
         /// <summary>
         /// Creates nested renderer components for a given series element, such as marker renderer, data label renderer, error bar renderer, and gradient renderers, based on the presence of their respective RendererType properties. Each nested renderer is also assigned a unique key for Blazor's rendering system. This method ensures that all auxiliary renderers associated with a series are instantiated and linked to the series for proper rendering of markers, labels, error bars, and gradients as needed.
         /// </summary>
-        private static void CreateSeriesNestedElements(RenderTreeBuilder builder, ChartSeries element, SfChart Chart)
+        private static void CreateSeriesNestedElements(RenderTreeBuilder builder, ChartSeries element)
         {
             int seq = 0;
             ChartSeries series = element;
-            bool isStaticSsr = Chart != null && Chart.IsStaticServerRendering();
 
             bool shouldOpenMarker = series.Marker?.RendererType is not null &&
-                        (series.Marker.Visible || series.Marker.DataLabel.Visible || isStaticSsr);
+                        (series.Marker.Visible || series.Marker.DataLabel.Visible);
             if (shouldOpenMarker)
             {
                 builder.OpenComponent(seq++, series.Marker.RendererType);
@@ -710,7 +709,7 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
 
                 foreach (ChartSeries element in Elements.Cast<ChartSeries>())
                 {
-                    CreateSeriesNestedElements(builder, element, Owner ?? null!);
+                    CreateSeriesNestedElements(builder, element);
                 }
             }
             else
@@ -740,7 +739,7 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
                             continue;
                         }
 
-                        CreateSeriesNestedElements(builder, element, Owner ?? null!);
+                        CreateSeriesNestedElements(builder, element);
                     }
                 }
             }
@@ -987,12 +986,9 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
                     Owner?._striplineOverContainer?.SetDefaultRendererValues();
                 }
             }
-            catch
+            catch (Exception exception) when (IsDisposed)
             {
-                if (!IsDisposed)
-                {
-                    throw;
-                }
+                System.Diagnostics.Debug.WriteLine($"Chart series renderer initialization failed during disposal: {exception}");
             }
         }
 

--- a/src/Components/Charts/Chart/Renderer/SeriesRenderers/MarkerRenders/ChartMarkerRenderer.cs
+++ b/src/Components/Charts/Chart/Renderer/SeriesRenderers/MarkerRenders/ChartMarkerRenderer.cs
@@ -13,6 +13,8 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
         #region Fields
         private string? _seriesIndex;
         private List<SymbolOptions> _symbolOptions = [];
+        // Static SSR is allowed once; subsequent passes use the normal renderer gate.
+        private bool _staticSSRRenderPending = true;
         #endregion
 
         #region Properties
@@ -359,12 +361,16 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
                 RenderMarkers(builder);
                 builder.CloseElement();
             }
+
+            if (IsStaticSSR())
+            {
+                _staticSSRRenderPending = false;
+            }
         }
 
         protected override bool ShouldRender()
         {
-            // Always allow the first SSR pass
-            return RendererShouldRender || IsStaticSSR();
+            return RendererShouldRender || (IsStaticSSR() && _staticSSRRenderPending);
         }
 
         #endregion

--- a/src/Components/Charts/Chart/Renderer/SeriesRenderers/MarkerRenders/ChartMarkerRenderer.cs
+++ b/src/Components/Charts/Chart/Renderer/SeriesRenderers/MarkerRenders/ChartMarkerRenderer.cs
@@ -361,6 +361,12 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
             }
         }
 
+        protected override bool ShouldRender()
+        {
+            // Always allow the first SSR pass
+            return RendererShouldRender || IsStaticSSR();
+        }
+
         #endregion
 
         #region Internal Methods
@@ -377,7 +383,7 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
         /// <returns>Calculated SymbolOptions instance.</returns>
         internal static SymbolOptions CalculateSymbol(ChartEventLocation location, string shape, Size size, string url, PathOptions option, SfChart chart)
         {
-            ChartEventLocation currentLocation = null!;
+            ChartEventLocation currentLocation = chart.IsStaticServerRendering() ? location : null!;
             if (chart is not null && shape == "Circle")
             {
                 string[] locations = ChartHelper.AppendTextElements(chart, option.Id, location.X, location.Y, "cx", "cy");
@@ -388,7 +394,10 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
 
             if (shapeoption.ShapeName == ShapeName.Path)
             {
-                shapeoption.PathOption.Direction = ChartHelper.AppendPathElements(chart ?? null!, shapeoption.PathOption.Direction, shapeoption.PathOption.Id);
+                if (chart != null)
+                {
+                    shapeoption.PathOption.Direction = ChartHelper.AppendPathElements(chart, shapeoption.PathOption.Direction, shapeoption.PathOption.Id);
+                }
                 shapeoption.PathOption.Visibility = option.Visibility;
             }
 
@@ -504,6 +513,20 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
                     symbolOption.PathOption.StrokeWidth = width;
                 }
             }
+        }
+
+        /// <summary>
+        /// SSR entry point – computes marker symbols when OnAfterRenderAsync is unavailable.
+        /// </summary>
+        internal override void SetDefaultRendererValues()
+        {
+            SeriesRenderer = Series?.Renderer;
+            if (SeriesRenderer != null && (Series?.Marker?.Visible ?? false))
+            {
+                CalculateRenderTreeBuilderOptions();   // fills _symbolOptions
+                SeriesRenderer.CalculateMarkerClipPath();
+            }
+            RendererShouldRender = true;
         }
 
         #endregion

--- a/src/Components/Charts/Chart/Renderer/StriplineRenderer/ChartStriplineContainer.cs
+++ b/src/Components/Charts/Chart/Renderer/StriplineRenderer/ChartStriplineContainer.cs
@@ -151,13 +151,14 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
         /// <param name="builder">RenderTreeBuilder instance.</param>
         protected override void BuildRenderers(RenderTreeBuilder builder)
         {
-            if (IsStaticSSR())
-            {
-                SetDefaultRendererValues();
-            }
             if (builder is null)
             {
                 return;
+            }
+
+            if (IsStaticSSR())
+            {
+                SetDefaultRendererValues();
             }
 
             Sequence = 0;
@@ -222,14 +223,14 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
         /// <param name="builder">RenderTreeBuilder instance.</param>
         protected override void BuildRenderers(RenderTreeBuilder builder)
         {
-            if (IsStaticSSR())
-            {
-                SetDefaultRendererValues();
-            }
-
             if (builder is null)
             {
                 return;
+            }
+
+            if (IsStaticSSR())
+            {
+                SetDefaultRendererValues();
             }
 
             Sequence = 0;

--- a/src/Components/Charts/Chart/Renderer/StriplineRenderer/ChartStriplineContainer.cs
+++ b/src/Components/Charts/Chart/Renderer/StriplineRenderer/ChartStriplineContainer.cs
@@ -65,7 +65,9 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
             {
                 ClipRect = Owner._axisContainer.AxisLayout.SeriesClipRect ?? null!;
             }
+
             HandleChartSizeChange(Owner?.InitialRect ?? new Rect(0, 0, 0, 0));
+            RendererShouldRender = true;
         }
         #endregion
 
@@ -149,14 +151,13 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
         /// <param name="builder">RenderTreeBuilder instance.</param>
         protected override void BuildRenderers(RenderTreeBuilder builder)
         {
-            if (builder is null)
-            {
-                return;
-            }
-
             if (IsStaticSSR())
             {
                 SetDefaultRendererValues();
+            }
+            if (builder is null)
+            {
+                return;
             }
 
             Sequence = 0;
@@ -221,14 +222,14 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
         /// <param name="builder">RenderTreeBuilder instance.</param>
         protected override void BuildRenderers(RenderTreeBuilder builder)
         {
-            if (builder is null)
-            {
-                return;
-            }
-
             if (IsStaticSSR())
             {
                 SetDefaultRendererValues();
+            }
+
+            if (builder is null)
+            {
+                return;
             }
 
             Sequence = 0;

--- a/src/Components/Charts/Chart/Renderer/StriplineRenderer/ChartStriplineRenderer.cs
+++ b/src/Components/Charts/Chart/Renderer/StriplineRenderer/ChartStriplineRenderer.cs
@@ -643,6 +643,18 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
             }
         }
 
+        /// <summary>
+        /// SSR entry point – calculates stripline geometry when OnAfterRenderAsync is unavailable.
+        /// </summary>
+        internal override void SetDefaultRendererValues()
+        {
+            if (Stripline != null)
+            {
+                InitStripline();   // this is the method that already exists and fills the path/rect collections
+            }
+            RendererShouldRender = true;
+        }
+
         #endregion
 
         #region Public Methods

--- a/src/Components/Charts/Chart/Series/Marker/ChartMarker.cs
+++ b/src/Components/Charts/Chart/Series/Marker/ChartMarker.cs
@@ -1,6 +1,7 @@
-﻿using System.ComponentModel;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using Syncfusion.Blazor.Toolkit.Charts.Internal;
+using System.ComponentModel;
 
 namespace Syncfusion.Blazor.Toolkit.Charts
 {
@@ -99,9 +100,40 @@ namespace Syncfusion.Blazor.Toolkit.Charts
         /// </summary>
         private void SetDefaultRendererValues()
         {
-            if (Series?.Container is not null && Series.Renderer is not null && Series.Renderer.IsStaticSSR())
+            // Guard everything – any of these can still be null on the first SSR pass
+            if (Series == null || Series.Container == null || Series.Renderer == null)
             {
-                Series.Container._seriesContainer?.Prerender();
+                return;
+            }
+
+            if (!Series.Renderer.IsStaticSSR())
+            {
+                return;
+            }
+
+            // 1. Force the series container to run its layout / prerender
+            Series.Container._seriesContainer?.Prerender();
+
+            // 2. If the marker renderer component already exists, force it to calculate symbols
+            var markerRenderer = Series.Marker?.Renderer;
+            if (markerRenderer != null)
+            {
+                var rect = Series.Container.InitialRect ?? new Rect(0, 0, 0, 0);
+                markerRenderer.HandleChartSizeChange(rect);
+            }
+            else
+            {
+                // Renderer component has not been created yet.
+                // Just ask the series renderer to re-render; the OpenComponent will happen later.
+                try
+                {
+                    Series.Renderer.RendererShouldRender = true;
+                    Series.Renderer.ProcessRenderQueue();
+                }
+                catch
+                {
+                    // Ignore – under pure SSR ProcessRenderQueue may not be fully ready
+                }
             }
         }
 

--- a/src/Components/Charts/Chart/Series/Marker/ChartMarker.cs
+++ b/src/Components/Charts/Chart/Series/Marker/ChartMarker.cs
@@ -114,26 +114,12 @@ namespace Syncfusion.Blazor.Toolkit.Charts
             // 1. Force the series container to run its layout / prerender
             Series.Container._seriesContainer?.Prerender();
 
-            // 2. If the marker renderer component already exists, force it to calculate symbols
+            // Recalculate symbols when the marker renderer component already exists.
             var markerRenderer = Series.Marker?.Renderer;
             if (markerRenderer != null)
             {
                 var rect = Series.Container.InitialRect ?? new Rect(0, 0, 0, 0);
                 markerRenderer.HandleChartSizeChange(rect);
-            }
-            else
-            {
-                // Renderer component has not been created yet.
-                // Just ask the series renderer to re-render; the OpenComponent will happen later.
-                try
-                {
-                    Series.Renderer.RendererShouldRender = true;
-                    Series.Renderer.ProcessRenderQueue();
-                }
-                catch
-                {
-                    // Ignore – under pure SSR ProcessRenderQueue may not be fully ready
-                }
             }
         }
 

--- a/src/Components/Charts/Chart/SfChart.razor.cs
+++ b/src/Components/Charts/Chart/SfChart.razor.cs
@@ -1728,14 +1728,16 @@ namespace Syncfusion.Blazor.Toolkit.Charts
                     CalculateAvailableSize();
                     SetInitialRect();
 
-                    // Critical for SSR – process data & layout synchronously
+                    // Border initialization reaches this method before the normal layout pass;
+                    // process data first so the synchronous prerender sees populated renderers.
+                    // IsSizeSet keeps this SSR-only initialization from repeating.
                     ProcessData();
-                    Prerender();                     // series / axis / column / row / annotation
+                    Prerender();
                 }
             }
-            catch
+            catch (Exception exception) when (IsDisposed)
             {
-                if (!IsDisposed) throw;
+                System.Diagnostics.Debug.WriteLine($"Static chart initialization failed during disposal: {exception}");
             }
         }
 

--- a/src/Components/Charts/Chart/SfChart.razor.cs
+++ b/src/Components/Charts/Chart/SfChart.razor.cs
@@ -588,7 +588,7 @@ namespace Syncfusion.Blazor.Toolkit.Charts
         private void CalculateAvailableSize()
         {
             double height = Height != NullDimensionValue ? ChartHelper.StringToNumber(Height, _elementOffset.Height) : ChartDefaultHeight;
-            double width = Width != NullDimensionValue ? ChartHelper.StringToNumber(Width, _elementOffset.Width) : ChartDefaultHeight;
+            double width = Width != NullDimensionValue ? ChartHelper.StringToNumber(Width, _elementOffset.Width) : ChartDefaultWidth;
 
             AvailableSize = new Size(width > 0 ? width : AvailableSize.Width, height > 0 ? height : AvailableSize.Height);
             if (EnableAdaptiveRendering)
@@ -1718,16 +1718,24 @@ namespace Syncfusion.Blazor.Toolkit.Charts
             {
                 if (!_render.IsSizeSet)
                 {
+                    // Force defaults when no DOM measurement is possible
+                    if (_elementOffset.Width <= 0 || _elementOffset.Height <= 0)
+                    {
+                        _svgWidth  ??= ChartDefaultWidth.ToString(CultureInfo.InvariantCulture);
+                        _svgHeight ??= ChartDefaultHeight.ToString(CultureInfo.InvariantCulture);
+                    }
+
                     CalculateAvailableSize();
                     SetInitialRect();
+
+                    // Critical for SSR – process data & layout synchronously
+                    ProcessData();
+                    Prerender();                     // series / axis / column / row / annotation
                 }
             }
             catch
             {
-                if (!IsDisposed)
-                {
-                    throw;
-                }
+                if (!IsDisposed) throw;
             }
         }
 

--- a/src/Components/Charts/Common/ChartUtils/ChartHelper.cs
+++ b/src/Components/Charts/Common/ChartUtils/ChartHelper.cs
@@ -1215,6 +1215,14 @@ namespace Syncfusion.Blazor.Toolkit.Charts.Internal
         /// <returns>An array containing the string representation of X and Y coordinates.</returns>
         internal static string[] AppendTextElements(SfChart chart, string id, double locationX, double locationY, string x = "x", string y = "y")
         {
+            if (chart == null && chart.IsStaticServerRendering())
+            {
+                return new string[]
+                {
+                    locationX.ToString(CultureInfo.InvariantCulture),
+                    locationY.ToString(CultureInfo.InvariantCulture)
+                };
+            }
             bool redraw = chart._redraw;
 
             if (chart._textAnimationElements.TryGetValue(id, out DynamicTextAnimationOptions? existElement))


### PR DESCRIPTION
**Description**

With Blazor interactivity set to none (Static SSR), Syncfusion charts did not render correctly or at all. Interactive modes were fine. Static SSR has no OnAfterRenderAsync or reliable DOM measurement. Layout and child renderers depended on post-render hooks and JS, so the first (and only) server pass never finished size, series, axis, or decoration rendering.

**Key Changes**

Detect SSR via IsStaticServerRendering(), set default SVG size (e.g. 600×450), run layout through SetDefaultRendererValues / HandleChartSizeChange from BuildRenderTree / Prerender, and keep all interactive-only behavior behind SSR checks.

**Files Affected**

Charts

- src/Components/Charts/Chart/Renderer/SeriesRenderers/BaseRenderers/SeriesContainer.cs
- src/Components/Charts/Chart/Renderer/SeriesRenderers/MarkerRenders/ChartMarkerRenderer.cs
- src/Components/Charts/Chart/Renderer/StriplineRenderer/ChartStriplineContainer.cs
- src/Components/Charts/Chart/Renderer/StriplineRenderer/ChartStriplineRenderer.cs
- src/Components/Charts/Chart/Renderer/ChartElementRenderer.cs
- src/Components/Charts/Chart/Series/Marker/ChartMarker.cs
- src/Components/Charts/Chart/SfChart.razor.cs
- src/Components/Charts/Common/ChartUtils/ChartHelper.cs

Samples & Tests

- Sample pages under samples/Blazor.Toolkit.Samples.Client/... (tested charts samples)
- Playwright samples and specs under tests/Syncfusion.Blazor.Playwright.Test/... (Charts)
